### PR TITLE
Improve sentiment preprocessing resilience and add tests

### DIFF
--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,37 @@
+import README as project
+
+
+def test_preprocess_text_normalizes_and_filters():
+    tokens = project.preprocess_text("Que buen servicio!!! 😃 xq llegó rápido")
+    # "que" debe normalizarse y filtrarse como stopword
+    assert "que" not in tokens
+    assert "buen" in tokens
+    assert "servicio" in tokens
+    assert "rapido" in tokens or "rápido" in tokens
+
+
+def test_analyze_sentiment_accepts_custom_analyzer():
+    stub_outputs = [
+        {"label": "POS", "score": 0.9},
+        {"label": "NEG", "score": 0.2},
+    ]
+
+    def stub_analyzer(reviews, truncation=True):
+        assert truncation is True
+        return stub_outputs[: len(reviews)]
+
+    labels, scores = project.analyze_sentiment(
+        ["Me encantó", "No me gustó"], analyzer=stub_analyzer
+    )
+
+    assert labels == ["pos", "neg"]
+    assert scores == [0.9, 0.2]
+
+
+def test_load_spanish_stopwords_fallback(monkeypatch):
+    monkeypatch.setattr(project, "stopwords", None)
+
+    fallback = project.load_spanish_stopwords()
+
+    assert isinstance(fallback, set)
+    assert {"de", "la", "que"}.issubset(fallback)


### PR DESCRIPTION
## Summary
- make optional dependencies lazy or resilient so preprocessing works even without external libraries
- allow providing a custom analyzer to the sentiment function to ease testing and offline use
- add pytest coverage for the text preprocessing and sentiment analysis helper
- add a fallback stopwords unit test so the suite now includes three checks

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2c3c52d2c832f8b76e1078a0f4c36